### PR TITLE
Add exclude_attribute option for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,23 @@ Output:
   BlueprintAgreement::Config.configure do |config|
     config.port = '8082'
     config.server_path = '.'
+    config.exlude_attributes = ['field_name']
   end
 ```
 
+### Exclude attributes
+
+This config option intents to exclude attributes when the match is perform. It only works with **JSON structures**
+
+Examples:
+
+``` ruby
+# This excludes 'field_one' and the element 'sub_field_one' inside the 'field_two' array. It doesn't exclude 'field_two'.
+BlueprintAgreement::Config.exclude_attributes = ['field_one', field_two: [ 'sub_field_one' ]]
+
+# This excludes 'field_one' and 'sub_field_four'. It doesn't exclude 'field_two' or 'sub_field_one'.
+BlueprintAgreement::Config.exclude_attributes = ['field_one', field_two: { sub_field_one: [ 'sub_field_four' ] } ]
+```
 
 ## Contributing
 

--- a/blueprint_agreement.gemspec
+++ b/blueprint_agreement.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.add_runtime_dependency "activesupport", ">= 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~>11.1"

--- a/lib/blueprint_agreement.rb
+++ b/lib/blueprint_agreement.rb
@@ -12,6 +12,7 @@ require 'blueprint_agreement/request_builder'
 require 'blueprint_agreement/utils/request_logger'
 require 'blueprint_agreement/utils/requester'
 require 'blueprint_agreement/utils/response_parser'
+require 'blueprint_agreement/utils/exclude_filter'
 require 'blueprint_agreement/minitest/assertions'
 require 'blueprint_agreement/minitest/expectations'
 

--- a/lib/blueprint_agreement/config.rb
+++ b/lib/blueprint_agreement/config.rb
@@ -2,6 +2,7 @@ module BlueprintAgreement
   module Config
     extend self
     @@active_service = nil
+    @@exclude_attributes = nil
 
     def configure; yield self end
 
@@ -11,6 +12,10 @@ module BlueprintAgreement
 
     def server_path=(server_path)
       @server_path = server_path
+    end
+
+    def exclude_attributes=(exclude_attributes)
+      @@exclude_attributes = exclude_attributes
     end
 
     def active_service?
@@ -36,6 +41,10 @@ module BlueprintAgreement
     def port
       #default port so 8081
       @port || '8081'
+    end
+
+    def exclude_attributes
+      @@exclude_attributes
     end
   end
 end

--- a/lib/blueprint_agreement/minitest/assertions.rb
+++ b/lib/blueprint_agreement/minitest/assertions.rb
@@ -1,7 +1,7 @@
 module Minitest
   module Assertions
     def assert_shall_agree_upon contract_name, response
-      result    = BlueprintAgreement::Utils.response_parser(response.body)
+      result    = response.body
       api_service =  BlueprintAgreement::DrakovService.new
       server    = BlueprintAgreement::Server.new(
         api_service: api_service,
@@ -12,7 +12,21 @@ module Minitest
         server.start(contract_name)
         request = BlueprintAgreement::RequestBuilder.for(self)
         requester = BlueprintAgreement::Utils::Requester.new(request, server)
-        expected  = BlueprintAgreement::Utils.response_parser(requester.perform.body)
+        expected  = requester.perform.body.to_s
+
+        unless BlueprintAgreement::Config.exclude_attributes.nil?
+          filters = BlueprintAgreement::Config.exclude_attributes
+          result = BlueprintAgreement::ExcludeFilter.deep_exclude(
+            BlueprintAgreement::Utils.to_json(result),
+            filters)
+          expected = BlueprintAgreement::ExcludeFilter.deep_exclude(
+            BlueprintAgreement::Utils.to_json(expected),
+            filters)
+        end
+
+        result = BlueprintAgreement::Utils.response_parser(result)
+        expected = BlueprintAgreement::Utils.response_parser(expected)
+
         assert_equal expected, result
       end
     end

--- a/lib/blueprint_agreement/utils/exclude_filter.rb
+++ b/lib/blueprint_agreement/utils/exclude_filter.rb
@@ -1,0 +1,71 @@
+require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/array/wrap'
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/object/blank'
+
+
+module BlueprintAgreement
+  class ExcludeFilter
+    class << self
+      def deep_exclude(content, exclude_attributes)
+        return content if content.blank? || !content.is_a?(Hash)
+        new(exclude_attributes).deep_exclude(content)
+      end
+    end
+
+    def initialize(exclude_attributes)
+      @exclude_attributes = exclude_attributes
+    end
+
+    def deep_exclude(content)
+      return content if @exclude_attributes.nil?
+
+      content.with_indifferent_access.tap do |params|
+        @exclude_attributes.flatten.each do |filter|
+          case filter
+          when Symbol, String
+            params.delete(filter) && params if params.has_key?(filter)
+          when Hash then
+            hash_filter(params, filter)
+          end
+        end
+      end
+    end
+
+    private
+
+    def hash_filter(params, filter)
+      filter = filter.with_indifferent_access
+
+      params.slice(*filter.keys).each do |key, value|
+        next unless value
+        next unless params.has_key? key
+
+        if value.is_a?(Array) || value.is_a?(Hash)
+          params[key] = each_element(value) do |element|
+            self.class.deep_exclude(element, Array.wrap(filter[key]))
+          end
+        end
+      end
+    end
+
+    def each_element(object)
+      case object
+      when Array
+        object.grep(Hash).map { |el| yield el }.compact
+      when Hash
+        if fields_for_style? object
+          hash = object.class.new
+          object.each { |k,v| hash[k] = yield v }
+          hash
+        else
+          yield object
+        end
+      end
+    end
+
+    def fields_for_style?(object)
+      object.is_a?(Hash) && object.all? { |k, v| k =~ /\A-?\d+\z/ && v.is_a?(Hash) }
+    end
+  end
+end

--- a/lib/blueprint_agreement/utils/response_parser.rb
+++ b/lib/blueprint_agreement/utils/response_parser.rb
@@ -2,8 +2,21 @@ require 'json'
 
 module BlueprintAgreement
   module Utils
-    def self.response_parser(response)
-      JSON.pretty_generate(JSON.parse(response || ""))
+    extend self
+
+    def to_json(content)
+      return content if content.nil?
+
+      JSON.parse(content, symbolize_names: true)
+    rescue JSON::ParserError
+      return content.to_s.lstrip
+    end
+
+    def response_parser(response)
+      return content if response.nil?
+
+      response = JSON.parse(response) if response.is_a? String
+      JSON.pretty_generate(response)
     rescue JSON::ParserError
       return response.to_s.lstrip
     end

--- a/test/fixtures/hello_api.md
+++ b/test/fixtures/hello_api.md
@@ -21,11 +21,17 @@ API Blueprint** and as such you can **parse** it with the
 + [Next: Resource and Actions](02.%20Resource%20and%20Actions.md)
 
 # GET /message
-+ Request  200 (application/json)
++ Request  (application/json)
 + Response 200 (application/json)
     
     + Body
 
             {
-              'name': 'Hello World'
+              "name": "Hello World"
             }
+
+# POST /message/empty
++ Request  (application/json)
++ Response 204 (application/json)
+ 
+    + Body

--- a/test/integration/simple_api_test.rb
+++ b/test/integration/simple_api_test.rb
@@ -8,7 +8,7 @@ class RackTestSession
 end
 
 describe "Rack Test" do
-  let(:body) { "\n{\n  'name': 'Hello World'\n}\n" }
+  let(:body) { JSON.generate({name: 'Hello World' }) }
   let(:last_request) { RailsMocks::Request.new(fullpath: endpoint) }
   let(:last_response) { RailsMocks::Response.new(body: body, request: last_request) }
   let(:rack_test_session) {  RackTestSession.new }
@@ -35,6 +35,33 @@ describe "Rack Test" do
     let(:endpoint){ '/not_valid' }
     it 'returns a Not Found Route error' do
       expect { last_response.shall_agree_upon('hello_api.md') }.must_raise(BlueprintAgreement::EndpointNotFound)
+    end
+  end
+
+  describe 'with exclude_attributes' do
+    let(:body) { "\n{}\n" }
+    let(:endpoint){ '/message' }
+
+    before do
+      BlueprintAgreement::Config.exclude_attributes = ['name']
+    end
+
+    it 'returns a Not Found Route error' do
+     last_response.shall_agree_upon('hello_api.md')
+    end
+  end
+
+  describe 'with blank results' do
+    let(:body) { "" }
+    let(:endpoint){ '/message/empty' }
+    let(:last_request) { RailsMocks::Request.new(fullpath: endpoint, request_method: 'POST') }
+
+    before do
+      BlueprintAgreement::Config.exclude_attributes = ['name']
+    end
+
+    it 'returns a Not Found Route error' do
+     last_response.shall_agree_upon('hello_api.md')
     end
   end
 end

--- a/test/unit_test/utils/exclude_filter_test.rb
+++ b/test/unit_test/utils/exclude_filter_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+require 'json'
+require 'blueprint_agreement/utils/exclude_filter'
+
+describe BlueprintAgreement::ExcludeFilter do
+  let(:described_module) { BlueprintAgreement::ExcludeFilter }
+
+  describe 'deep_exclude' do
+    let(:response) do
+      {
+        actor: "Morgan Freeman",
+        age: 79,
+        nominations: {
+          oscars: [
+            { year: 2010 },
+            { year: 2005 }
+          ]
+
+        },
+        movies: [
+          {
+            name: 'angel has fallen',
+            year: 2018
+          },
+          {
+            name: 'Brubaker',
+            year: 1980
+          }
+        ]
+      }
+    end
+
+    it 'returns a filtered result' do
+      exclude_attributes = ['age', movies: ['year'], nominations: { oscars: ['year'] }]
+      expected_result = {
+        actor: "Morgan Freeman",
+        nominations: {
+          oscars: [
+            { },
+            { }
+          ]
+        },
+        movies: [
+          {
+            name: 'angel has fallen'
+          },
+          {
+            name: 'Brubaker'
+          }
+        ]
+      }
+
+      filtered_response = described_module.deep_exclude(response, exclude_attributes)
+      expect(JSON.generate(filtered_response)).must_equal(JSON.generate(expected_result))
+    end
+
+    it 'returns an empty hash when all the attributes were excluded' do
+      exclude_attributes = ['age', 'movies', 'actor', 'nominations']
+      filtered_response = described_module.deep_exclude(response, exclude_attributes)
+      expect(filtered_response).must_equal({})
+    end
+
+    it 'returns the same hash when exclude_attributes is nil' do
+      exclude_attributes = nil
+      filtered_response = described_module.deep_exclude(response, exclude_attributes)
+      expect(JSON.generate(filtered_response)).must_equal(JSON.generate(response))
+    end
+  end
+end


### PR DESCRIPTION
### Description
This config option intents to exclude attributes when the match is perform. It only works with **JSON structures**.

`exclude_attributes` option works pretty similar of  `permit` params in Rails.

### Example

``` ruby
# { field_one: 1, field_two: 2 }
BlueprintAgreement::Config.exclude_attributes = ['field_one', 'field_two']
#  { field_one:  [ { field_two: 2 } ] }
BlueprintAgreement::Config.exclude_attributes = [field_one: [ 'field_two' ]]
#  { field_one:  { field_two: [ 'field_three' }  }
BlueprintAgreement::Config.exclude_attributes = [field_one: { field_two: [ 'field_third' ] }]
```