### PR TITLE
Allow Cookie header

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A Minitest API Documentation Matcher based on ApiBluePrint schema.
 
-Note: This Gem Is Currently on Development. 
+Note: This Gem Is Currently on Development.
 
 ## Description
 
@@ -63,7 +63,7 @@ FORMAT: 1A
 
 Then, test your documentation:
 
-``` ruby 
+```ruby
 
 describe Test do
   it 'has a valid response' do
@@ -78,32 +78,26 @@ use a env variable calls `AGREEMENT_LOUD`
 
 ``` bash
   $ AGREEMENT_LOUD=true rake test
-``` 
+```
 
 Output:
 
-``` bash
+```bash
 ...Drakov server output...
 [DRAKOV] GET /message example
 
-          Method: GET
-          Path: http://localhost:8082/message
+Method: GET
+Path: http://localhost:8082/message
 
-          Details
+Headers:
+Content-Type: application/json
+Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.example
 
-          Headers:
-
-           
-            Content-Type=application/json
-            Authorization=Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.example
-
-          Body:
-          
-            {"param_1": "hi"}
-        
-
+Body:
+{"param_1": "hi"}
 ```
-### Config File 
+
+### Config File
 
 /config/initializer/blueprint_agreement.rb
 

--- a/lib/blueprint_agreement/api_services/drakov_service.rb
+++ b/lib/blueprint_agreement/api_services/drakov_service.rb
@@ -9,7 +9,7 @@ module BlueprintAgreement
     end
 
     def start(path)
-      @pid = spawn "drakov -f  #{root_path}/#{path} -p #{port} --header Authorization", options
+      @pid = spawn "drakov -f  #{root_path}/#{path} -p #{port} --header Authorization --header Cookie", options
       Config.active_service = { pid: @pid, path: path }
     end
 

--- a/lib/blueprint_agreement/request_builder.rb
+++ b/lib/blueprint_agreement/request_builder.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/hash/compact'
+
 module BlueprintAgreement
   class RequestBuilder
 
@@ -52,7 +54,12 @@ module BlueprintAgreement
     end
 
     class RailsRequest
-      HEADER_PATCH = {"CONTENT_TYPE" => "Content-Type", "HTTP_AUTHORIZATION" => "Authorization"}
+      HEADER_PATCH = {
+        "CONTENT_TYPE" => "Content-Type",
+        "HTTP_AUTHORIZATION" => "Authorization",
+        "rack.request.cookie_string" => "Cookie",
+        "HTTP_COOKIE" => "Cookie",
+      }
 
       def initialize(context)
         @context = context
@@ -75,9 +82,10 @@ module BlueprintAgreement
       end
 
       def headers
-        HEADER_PATCH.each_with_object({}) do  |header, result|
+        HEADER_PATCH.each_with_object({}) do |header, result|
           header_name, key = header
-          result[key] = @context.request.headers[header_name]
+          next unless @context.request.env.key?(header_name)
+          result[key] = @context.request.env[header_name]
         end.compact
       end
 

--- a/lib/blueprint_agreement/utils/request_logger.rb
+++ b/lib/blueprint_agreement/utils/request_logger.rb
@@ -13,19 +13,16 @@ module BlueprintAgreement
       end
 
       def print
-        header_output =  @headers.to_a.map { |header| header.join("=") }.join("\n")
+        header_output =  @headers.to_a.map { |header| header.join(": ") }.join("\n")
         %{
-          Method: #{@request_method}
-          Path: #{@path}
+Method: #{@request_method}
+Path: #{@path}
 
-          Details
+Headers:
+#{ header_output }
 
-          Headers:
-
-          #{ header_output }
-
-          Body:
-          #{@body}
+Body:
+#{@body}
         }
       end
     end

--- a/test/fixtures/hello_api.md
+++ b/test/fixtures/hello_api.md
@@ -35,3 +35,18 @@ API Blueprint** and as such you can **parse** it with the
 + Response 204 (application/json)
  
     + Body
+
+# GET /cookie
++ Request (application/json)
+  
+    + Headers
+
+            Cookie: cookie=have-a-cookie
+
++ Response 200 (application/json)
+  
+    + Body
+
+            {
+              "cookie": "have a cookie!"
+            }

--- a/test/integration/simple_api_test.rb
+++ b/test/integration/simple_api_test.rb
@@ -1,17 +1,44 @@
 require 'test_helper'
 require 'blueprint_agreement'
 
-class RackTestSession
-  def initialize
-    @headers = { "Content-Type" => "application/json" }
+describe "Rails" do
+  let(:body) { JSON.generate({cookie: 'have a cookie!' }) }
+  let(:env) do
+    {
+      'HTTP_COOKIE' => 'cookie=have-a-cookie',
+      'CONTENT_TYPE' => 'application/json'
+    }
+  end
+  let(:request) { RailsMocks::Request.new(fullpath: endpoint, env: env) }
+  let(:last_response) { RailsMocks::Response.new(body: body, request: request) }
+
+  before do
+    module Rails; end
+    BlueprintAgreement::Config.server_path('./test/fixtures')
+  end
+  after do
+    Object.send(:remove_const, :Rails)
+  end
+
+  describe 'cookies' do
+    let(:endpoint) { '/cookie' }
+    it 'returns a valid request' do
+      last_response.shall_agree_upon('hello_api.md')
+    end
   end
 end
 
 describe "Rack Test" do
+  class RackTestSession
+    def initialize
+      @headers = { "Content-Type" => "application/json" }
+    end
+  end
+
   let(:body) { JSON.generate({name: 'Hello World' }) }
   let(:last_request) { RailsMocks::Request.new(fullpath: endpoint) }
   let(:last_response) { RailsMocks::Response.new(body: body, request: last_request) }
-  let(:rack_test_session) {  RackTestSession.new }
+  let(:rack_test_session) { RackTestSession.new }
 
   before do
     module Rack; module Test; end; end

--- a/test/support/rails_mocks/request.rb
+++ b/test/support/rails_mocks/request.rb
@@ -1,14 +1,14 @@
 module RailsMocks
   class Request
-    attr_reader  :fullpath, :request_method, :content_type, :authorization, :body
+    attr_reader  :fullpath, :request_method, :content_type, :authorization, :body, :env
 
-    def initialize(response: '', fullpath: '/message', request_method: 'GET', authorization: '', content_type: 'application/json', body: '')
-      @response = response
+    def initialize(fullpath: '/message', request_method: 'GET', authorization: '', content_type: 'application/json', body: '', env: {})
       @fullpath = URI(fullpath)
       @request_method = request_method
       @authorization = authorization
       @body = StringIO.new(body)
       @content_type = content_type
+      @env = env
     end
 
     def has_content_type?


### PR DESCRIPTION
Read cookie from `rack.request.cookie_string` or `HTTP_COOKIE` if available and send it has a header

* Rails replaces the `Cookie` header by `rack.request.cookie_string` header.
* Changes in the logger to improve output of request detail:
![captura de pantalla 2017-01-02 a las 2 18 10 p m](https://cloud.githubusercontent.com/assets/2790520/21596434/2ade274e-d109-11e6-8686-5364b7ca268e.png)
