### PR TITLE
Add allow_headers and hostname to config

### DIFF
--- a/lib/blueprint_agreement.rb
+++ b/lib/blueprint_agreement.rb
@@ -1,5 +1,3 @@
- # gem "minitest"
-require "minitest"
 require "minitest"
 require "minitest/spec"
 require "minitest/mock"
@@ -41,9 +39,6 @@ require 'blueprint_agreement/minitest/expectations'
 #    +-+-+                     +--+--+                           +-+-+
 #
 module BlueprintAgreement
-  Config.configure do |config|
-    config.port = '8082'
-  end
 end
 
 Minitest.after_run do

--- a/lib/blueprint_agreement/api_services/drakov_service.rb
+++ b/lib/blueprint_agreement/api_services/drakov_service.rb
@@ -1,15 +1,16 @@
 module BlueprintAgreement
   class DrakovService
-    attr :pid, :port, :hostname, :root_path
+    attr :pid, :port, :hostname, :root_path, :allow_headers
 
-    def initialize(hostname = 'http://localhost')
+    def initialize
       @port = Config.port
-      @hostname = hostname
+      @allow_headers = Config.allow_headers
+      @hostname = Config.hostname
       @root_path = Config.server_path
     end
 
     def start(path)
-      @pid = spawn "drakov -f  #{root_path}/#{path} -p #{port} --header Authorization --header Cookie", options
+      @pid = spawn "drakov -f #{root_path}/#{path} -p #{port} #{allow_headers}".strip, options
       Config.active_service = { pid: @pid, path: path }
     end
 
@@ -19,7 +20,7 @@ module BlueprintAgreement
     end
 
     def host
-      "http://localhost:#{port}"
+      "#{hostname}:#{port}"
     end
 
     def installed?

--- a/lib/blueprint_agreement/config.rb
+++ b/lib/blueprint_agreement/config.rb
@@ -3,11 +3,14 @@ module BlueprintAgreement
     extend self
     @@active_service = nil
     @@exclude_attributes = nil
+    @@allow_headers = nil
+    @@port = "8082"
+    @@hostname = "http://localhost"
 
     def configure; yield self end
 
     def port=(port)
-      @port = port
+      @@port = port
     end
 
     def server_path=(server_path)
@@ -34,13 +37,28 @@ module BlueprintAgreement
       @server_path ||= path
     end
 
+    def allow_headers=(headers)
+      @@allow_headers = headers.map { |header| "--header #{header}" }.join(" ")
+    end
+
+    def allow_headers
+      @@allow_headers
+    end
+
     def default_format
       '*.apib'
     end
 
     def port
-      #default port so 8081
-      @port || '8081'
+      @@port
+    end
+
+    def hostname
+      @@hostname
+    end
+
+    def hostname=(host)
+      @@hostname = host
     end
 
     def exclude_attributes

--- a/test/unit_test/utils/config_test.rb
+++ b/test/unit_test/utils/config_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+describe BlueprintAgreement::Config do
+  let(:subject) { BlueprintAgreement::Config }
+
+  describe 'allow headers' do
+    it 'allows setting the allowed headers' do
+      subject.allow_headers = ['Authorization', 'Cookie']
+      subject.allow_headers.must_equal('--header Authorization --header Cookie')
+      subject.allow_headers = []
+    end
+  end
+
+  describe 'port' do
+    it 'defaults to 8082' do
+      subject.port.must_equal('8082')
+    end
+
+    it 'sets the port' do
+      subject.port = '8080'
+      subject.port.must_equal('8080')
+      subject.port = '8082'
+    end
+  end
+
+  describe 'hostname' do
+    it 'sets the hostname' do
+      subject.hostname = 'http://host.test'
+      subject.hostname.must_equal('http://host.test')
+      subject.hostname = 'http://localhost'
+    end
+  end
+end


### PR DESCRIPTION
Each one of the allowed headers will be passed to drakov as `--header header`.
Hardcoded headers are removed from the drakov service.

Default port is set to 8082 in `Config` to remove the hardcoded configuration
in `lib/blueprint_agreement.rb`.

Normalize all config options in `Config` module to use `@@` instead of `@`.