### PR TITLE
Include ENV_METHODS to RailsRequest

### DIFF
--- a/test/fixtures/hello_api.md
+++ b/test/fixtures/hello_api.md
@@ -64,3 +64,20 @@ API Blueprint** and as such you can **parse** it with the
             {
               "cookie": "have a cookie!"
             }
+
+# GET /extra_headers
++ Request (application/json)
+
+    + Headers
+
+            Cookie: cookie=have-a-cookie
+            Accept: application/json
+            Version: v1
+
++ Response 200 (application/json)
+
+    + Body
+
+            {
+              "cookie": "have a cookie!"
+            }

--- a/test/integration/simple_api_test.rb
+++ b/test/integration/simple_api_test.rb
@@ -26,6 +26,22 @@ describe "Rails" do
       last_response.shall_agree_upon('hello_api.md')
     end
   end
+
+  describe 'extra_headers' do
+    let(:env) do
+      {
+        'HTTP_COOKIE' => 'cookie=have-a-cookie',
+        'CONTENT_TYPE' => 'application/json',
+        'HTTP_ACCEPT' => 'application/json',
+        'HTTP_VERSION' => 'v1'
+      }
+    end
+
+    let(:endpoint) { '/extra_headers' }
+    it 'returns a valid request' do
+      last_response.shall_agree_upon('hello_api.md')
+    end
+  end
 end
 
 describe "Rack Test" do


### PR DESCRIPTION
Description
====

`RailsRequest` is not including some `headers` in RailsRequest class because the are not include into the `HEADERS_PATCH.` I included some headers from  [Request::ENV_METHODS ](https://github.com/rails/rails/blob/d2dde6cbfc11bf39be30d22e2ee7c41c119e0d51/actionpack/lib/action_dispatch/http/request.rb#L30 ) as part of the `headers` method for RailsRequest. 
 